### PR TITLE
fix: Configure Vercel for monorepo deployment

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,7 @@
+backend/
+medibuddy/
+node_modules/
+*.md
+.git/
+.DS_Store
+.claude/

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,4 +1,29 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // Fix for monorepo deployments
+  output: 'standalone',
+
+  // Specify the tracing root for monorepo
+  outputFileTracingRoot: path.join(__dirname, '../'),
+
+  // Image optimization
+  images: {
+    unoptimized: false,
+    remotePatterns: [],
+  },
+
+  // Ensure static exports work properly
+  experimental: {
+    outputFileTracingIncludes: {
+      '/': ['./public/**/*'],
+    },
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Telesana",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd frontend && npm run build",
+  "devCommand": "cd frontend && npm run dev",
+  "installCommand": "cd frontend && npm install",
+  "framework": "nextjs",
+  "outputDirectory": "frontend/.next"
+}


### PR DESCRIPTION
- Delete empty root package-lock.json
- Add vercel.json with frontend directory configuration
- Add .vercelignore to exclude backend and other files
- Update next.config.mjs with standalone output and tracing root
- Fix monorepo structure for Vercel deployment